### PR TITLE
feat: data model, migration and seed

### DIFF
--- a/server/prisma/migrations/20260829115154_add_lab2_ticketing_models/migration.sql
+++ b/server/prisma/migrations/20260829115154_add_lab2_ticketing_models/migration.sql
@@ -1,0 +1,103 @@
+-- CreateEnum
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "CurrentStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Requester" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Requester_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "ticketDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "RequestedPriority" NOT NULL,
+    "currentStatus" "CurrentStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Requester_email_key" ON "Requester"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_idx" ON "Ticket"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_categoryId_idx" ON "Ticket"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_relatedSystemId_idx" ON "Ticket"("relatedSystemId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_ticketDate_idx" ON "Ticket"("ticketDate");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFilename_key" ON "Attachment"("storedFilename");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "Requester"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260830075952_fix_ticket_index_add_sequence/migration.sql
+++ b/server/prisma/migrations/20260830075952_fix_ticket_index_add_sequence/migration.sql
@@ -1,0 +1,17 @@
+-- DropIndex
+DROP INDEX "Ticket_requesterId_idx";
+
+-- DropIndex
+DROP INDEX "Ticket_ticketDate_idx";
+
+-- AlterTable
+ALTER TABLE "RelatedSystem" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_ticketDate_idx" ON "Ticket"("requesterId", "ticketDate");
+
+-- CreateSequence
+-- Backs the Ticket Number generator (Issue #13): the backend formats TKT-<year>-<6-digit>
+-- from nextval('ticket_number_seq') rather than exposing this as a Prisma-managed column,
+-- since Prisma has no first-class support for a standalone sequence (specification.md §11).
+CREATE SEQUENCE IF NOT EXISTS "ticket_number_seq" START WITH 1 INCREMENT BY 1;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -15,5 +15,80 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model Requester {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tickets Ticket[]
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum CurrentStatus {
+  NEW
+}
+
+model Ticket {
+  id                Int               @id @default(autoincrement())
+  ticketNumber      String            @unique
+  ticketDate        DateTime          @default(now())
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  summary           String
+  description       String
+  requestedPriority RequestedPriority
+  currentStatus     CurrentStatus     @default(NEW)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  requester     Requester     @relation(fields: [requesterId], references: [id])
+  category      Category      @relation(fields: [categoryId], references: [id])
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+  attachments   Attachment[]
+
+  @@index([requesterId])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+  @@index([ticketDate])
+}
+
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  originalFilename String
+  storedFilename   String    @unique
+  mimeType         String
+  sizeBytes        Int
+  uploadedAt       DateTime  @default(now())
+  isActive         Boolean   @default(true)
+  removedAt        DateTime?
+  removalReason    String?
+
+  ticket Ticket @relation(fields: [ticketId], references: [id])
+
+  @@index([ticketId])
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -26,6 +26,7 @@ model RelatedSystem {
   name      String   @unique
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   tickets Ticket[]
 }
@@ -70,10 +71,9 @@ model Ticket {
   relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id])
   attachments   Attachment[]
 
-  @@index([requesterId])
+  @@index([requesterId, ticketDate])
   @@index([categoryId])
   @@index([relatedSystemId])
-  @@index([ticketDate])
 }
 
 model Attachment {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -7,12 +7,45 @@ const prisma = new PrismaClient({ adapter });
 
 const categoryNames = ['Account and Access', 'Hardware', 'Software', 'Network'];
 
+const relatedSystemNames = [
+  'Campus Wi-Fi',
+  'Student Portal',
+  'Email',
+  'Learning Management System',
+  'Printing Service',
+  'VPN',
+];
+
+const requesters = [
+  { name: 'Anong Srisai', email: 'anong.srisai@toktickit.dev', isActive: true },
+  { name: 'Kritsada Boonmee', email: 'kritsada.boonmee@toktickit.dev', isActive: true },
+  { name: 'Suphachai Wattana', email: 'suphachai.wattana@toktickit.dev', isActive: true },
+  { name: 'Nalinee Chaiyaporn', email: 'nalinee.chaiyaporn@toktickit.dev', isActive: true },
+  { name: 'Ratchanee Somsak', email: 'ratchanee.somsak@toktickit.dev', isActive: false },
+];
+
 async function main() {
   for (const name of categoryNames) {
     await prisma.category.upsert({
       where: { name },
       update: {},
       create: { name },
+    });
+  }
+
+  for (const name of relatedSystemNames) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const requester of requesters) {
+    await prisma.requester.upsert({
+      where: { email: requester.email },
+      update: {},
+      create: requester,
     });
   }
 }


### PR DESCRIPTION
Closes #11

Adds the Lab 2 data layer per specification.md §7 and the seed per §12:

server/prisma/schema.prisma — five models (Category + isActive, RelatedSystem, Requester, Ticket, Attachment), two enums (RequestedPriority, CurrentStatus), FK relations and indexes matching the ownership/query patterns in api-spec.md
server/prisma/migrations/20260829115154_add_lab2_ticketing_models/ — the generated migration, applied and verified locally
server/prisma/seed.ts — idempotent upserts for 4 Categories, 6 Related Systems, and 5 Development Requesters (4 active, 1 inactive), matching labsheet §5.3

Verified via Prisma Studio (correct row counts, inactive Requester flagged) and a repeat prisma db seed run with no duplicates or errors.

No API or frontend changes — this is the schema/seed layer that Issue #12 onward builds against.