### PR TITLE
feature/13 create ticket and screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function Home() {
 
   return (
     <AppShell>
-      <p>Signed in as {requester.name}. My Tickets is coming in a later Issue.</p>
+      <p className="mb-3">Signed in as {requester.name}. My Tickets is coming in a later Issue.</p>
       <Link to="/create-ticket" className="btn btn-tt-primary">
         Create Ticket
       </Link>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,10 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import { RequesterProvider, useRequester } from './context/RequesterContext';
 import { RequesterSelector } from './pages/RequesterSelector';
 import { DiagnosticsPage } from './pages/DiagnosticsPage';
+import { CreateTicket } from './pages/CreateTicket';
 import { AppShell } from './components/AppShell';
+import { RequireRequester } from './components/RequireRequester';
 import './App.css';
 import './theme.css';
 
@@ -15,7 +17,10 @@ function Home() {
 
   return (
     <AppShell>
-      <p>Signed in as {requester.name}. My Tickets and Create Ticket are coming in later Issues.</p>
+      <p>Signed in as {requester.name}. My Tickets is coming in a later Issue.</p>
+      <Link to="/create-ticket" className="btn btn-tt-primary">
+        Create Ticket
+      </Link>
     </AppShell>
   );
 }
@@ -26,6 +31,16 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route
+            path="/create-ticket"
+            element={
+              <RequireRequester>
+                <AppShell>
+                  <CreateTicket />
+                </AppShell>
+              </RequireRequester>
+            }
+          />
           <Route path="/diagnostics" element={<DiagnosticsPage />} />
         </Routes>
       </BrowserRouter>

--- a/client/src/components/RequireRequester.tsx
+++ b/client/src/components/RequireRequester.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useRequester } from '../context/RequesterContext';
+
+// Redirects to the Requester Selection screen (Home, "/") when no Requester is selected.
+// Factored out once a second route needed the same check Home already did inline —
+// this is the shared route guard Chanat suggested (minor, PR #21 review) once it was
+// actually useful rather than speculative.
+export function RequireRequester({ children }: { children: ReactNode }) {
+  const { requester } = useRequester();
+
+  if (!requester) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,7 +35,6 @@
   width: 1126px;
   max-width: 100%;
   margin: 0 auto;
-  text-align: center;
   min-height: 100svh;
   display: flex;
   flex-direction: column;

--- a/client/src/pages/CreateTicket.tsx
+++ b/client/src/pages/CreateTicket.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useRequester } from '../context/RequesterContext';
+
+interface ReferenceItem {
+  id: number;
+  name: string;
+}
+
+type ReferenceState = 'loading' | 'loaded' | 'error';
+
+const REQUESTED_PRIORITIES = ['LOW', 'MEDIUM', 'HIGH'] as const;
+type RequestedPriority = (typeof REQUESTED_PRIORITIES)[number];
+
+const ALLOWED_ATTACHMENT_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+
+interface AttachmentRow {
+  file: File;
+  error: string | null;
+}
+
+interface FormValues {
+  categoryId: string;
+  relatedSystemId: string;
+  summary: string;
+  description: string;
+  requestedPriority: RequestedPriority | '';
+}
+
+type FieldName = keyof FormValues;
+
+type FieldErrors = Partial<Record<FieldName, string>>;
+
+const initialValues: FormValues = {
+  categoryId: '',
+  relatedSystemId: '',
+  summary: '',
+  description: '',
+  requestedPriority: '',
+};
+
+function validate(values: FormValues): FieldErrors {
+  const errors: FieldErrors = {};
+
+  if (!values.categoryId) {
+    errors.categoryId = 'Category is required.';
+  }
+  if (!values.relatedSystemId) {
+    errors.relatedSystemId = 'Related System is required.';
+  }
+
+  const summary = values.summary.trim();
+  if (summary.length < 5 || summary.length > 120) {
+    errors.summary = 'Summary must be 5-120 characters.';
+  }
+
+  const description = values.description.trim();
+  if (description.length < 10 || description.length > 2000) {
+    errors.description = 'Description must be 10-2000 characters.';
+  }
+
+  if (!values.requestedPriority) {
+    errors.requestedPriority = 'Requested Priority is required.';
+  }
+
+  return errors;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fileTypeLabel(file: File): string {
+  const ext = file.name.split('.').pop()?.toUpperCase();
+  return ext ?? 'FILE';
+}
+
+export function CreateTicket() {
+  const { requester } = useRequester();
+
+  const [categories, setCategories] = useState<ReferenceItem[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
+  const [referenceState, setReferenceState] = useState<ReferenceState>('loading');
+
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [touched, setTouched] = useState<Partial<Record<FieldName, boolean>>>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [successTicketNumber, setSuccessTicketNumber] = useState<string | null>(null);
+
+  const [attachments, setAttachments] = useState<AttachmentRow[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadReferenceData() {
+      setReferenceState('loading');
+      try {
+        const [categoriesResponse, relatedSystemsResponse] = await Promise.all([
+          fetch('/api/categories', { signal: AbortSignal.timeout(5000) }),
+          fetch('/api/related-systems', { signal: AbortSignal.timeout(5000) }),
+        ]);
+        if (!categoriesResponse.ok || !relatedSystemsResponse.ok) {
+          throw new Error('Backend returned an error');
+        }
+        const categoriesData: ReferenceItem[] = await categoriesResponse.json();
+        const relatedSystemsData: ReferenceItem[] = await relatedSystemsResponse.json();
+        if (cancelled) return;
+        setCategories(categoriesData);
+        setRelatedSystems(relatedSystemsData);
+        setReferenceState('loaded');
+      } catch {
+        if (!cancelled) {
+          setReferenceState('error');
+        }
+      }
+    }
+
+    loadReferenceData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const errors = validate(values);
+
+  const showError = (field: FieldName) => Boolean((touched[field] || submitAttempted) && errors[field]);
+
+  const handleChange =
+    (field: FieldName) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      setValues((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleBlur = (field: FieldName) => () => {
+    setTouched((prev) => ({ ...prev, [field]: true }));
+  };
+
+  const handleFilesSelected = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files) return;
+
+    const nextRows: AttachmentRow[] = Array.from(files).map((file) => {
+      if (!ALLOWED_ATTACHMENT_TYPES.includes(file.type)) {
+        return { file, error: 'File type not allowed. Use JPG, PNG, WEBP, or PDF.' };
+      }
+      if (file.size > MAX_ATTACHMENT_BYTES) {
+        return { file, error: 'File is over the 5 MB limit.' };
+      }
+      return { file, error: null };
+    });
+
+    setAttachments((prev) => [...prev, ...nextRows]);
+    event.target.value = '';
+  };
+
+  const removeAttachment = (index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSubmitAttempted(true);
+    setSubmitError(null);
+
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+    if (!requester || submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/tickets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requesterId: requester.id,
+          categoryId: Number(values.categoryId),
+          relatedSystemId: Number(values.relatedSystemId),
+          summary: values.summary.trim(),
+          description: values.description.trim(),
+          requestedPriority: values.requestedPriority,
+        }),
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (!response.ok) {
+        throw new Error('Backend returned an error');
+      }
+
+      const created = await response.json();
+      setSuccessTicketNumber(created.ticketNumber);
+    } catch {
+      // Deliberately does not touch `values` — AC-12 requires every entered field to
+      // still be there after a failed submission, not just a friendly message.
+      setSubmitError('Unable to reach the server. Your entered values have been kept — please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCreateAnother = () => {
+    setSuccessTicketNumber(null);
+    setValues(initialValues);
+    setTouched({});
+    setSubmitAttempted(false);
+    setAttachments([]);
+  };
+
+  if (successTicketNumber) {
+    return (
+      <div className="create-ticket">
+        <div className="alert alert-success" role="alert">
+          <p className="mb-1">Ticket created successfully.</p>
+          <p className="mb-0">
+            <strong>Ticket Number:</strong> {successTicketNumber}
+          </p>
+        </div>
+        <button type="button" className="btn btn-tt-primary" onClick={handleCreateAnother}>
+          Create Another Ticket
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="create-ticket">
+      <h1>Create Ticket</h1>
+
+      {submitError && (
+        <div className="alert alert-danger tt-alert-error" role="alert">
+          {submitError}
+        </div>
+      )}
+
+      <form noValidate onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Requester</label>
+          <input type="text" className="form-control tt-field-readonly" value={requester?.name ?? ''} readOnly />
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="category" className="form-label tt-required">
+            Category
+          </label>
+          <select
+            id="category"
+            className={`form-select${showError('categoryId') ? ' is-invalid' : ''}`}
+            value={values.categoryId}
+            onChange={handleChange('categoryId')}
+            onBlur={handleBlur('categoryId')}
+            disabled={referenceState !== 'loaded'}
+          >
+            <option value="" disabled>
+              {referenceState === 'loaded' ? 'Choose a Category…' : 'Loading…'}
+            </option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+          {showError('categoryId') && <div className="invalid-feedback d-block">{errors.categoryId}</div>}
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="relatedSystem" className="form-label tt-required">
+            Related System
+          </label>
+          <select
+            id="relatedSystem"
+            className={`form-select${showError('relatedSystemId') ? ' is-invalid' : ''}`}
+            value={values.relatedSystemId}
+            onChange={handleChange('relatedSystemId')}
+            onBlur={handleBlur('relatedSystemId')}
+            disabled={referenceState !== 'loaded'}
+          >
+            <option value="" disabled>
+              {referenceState === 'loaded' ? 'Choose a Related System…' : 'Loading…'}
+            </option>
+            {relatedSystems.map((relatedSystem) => (
+              <option key={relatedSystem.id} value={relatedSystem.id}>
+                {relatedSystem.name}
+              </option>
+            ))}
+          </select>
+          {showError('relatedSystemId') && (
+            <div className="invalid-feedback d-block">{errors.relatedSystemId}</div>
+          )}
+        </div>
+
+        {referenceState === 'error' && (
+          <div className="alert alert-danger tt-alert-error" role="alert">
+            Unable to load Categories or Related Systems. Please try again.
+          </div>
+        )}
+
+        <div className="mb-3">
+          <label htmlFor="summary" className="form-label tt-required">
+            Summary
+          </label>
+          <input
+            id="summary"
+            type="text"
+            className={`form-control${showError('summary') ? ' is-invalid' : ''}`}
+            value={values.summary}
+            onChange={handleChange('summary')}
+            onBlur={handleBlur('summary')}
+          />
+          {showError('summary') && <div className="invalid-feedback d-block">{errors.summary}</div>}
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="description" className="form-label tt-required">
+            Description
+          </label>
+          <textarea
+            id="description"
+            className={`form-control${showError('description') ? ' is-invalid' : ''}`}
+            rows={5}
+            value={values.description}
+            onChange={handleChange('description')}
+            onBlur={handleBlur('description')}
+          />
+          {showError('description') && <div className="invalid-feedback d-block">{errors.description}</div>}
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="requestedPriority" className="form-label tt-required">
+            Requested Priority
+          </label>
+          <select
+            id="requestedPriority"
+            className={`form-select${showError('requestedPriority') ? ' is-invalid' : ''}`}
+            value={values.requestedPriority}
+            onChange={handleChange('requestedPriority')}
+            onBlur={handleBlur('requestedPriority')}
+          >
+            <option value="" disabled>
+              Choose a Priority…
+            </option>
+            {REQUESTED_PRIORITIES.map((priority) => (
+              <option key={priority} value={priority}>
+                {priority.charAt(0) + priority.slice(1).toLowerCase()}
+              </option>
+            ))}
+          </select>
+          {showError('requestedPriority') && (
+            <div className="invalid-feedback d-block">{errors.requestedPriority}</div>
+          )}
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="attachments" className="form-label">
+            Attachments
+          </label>
+          <input
+            id="attachments"
+            type="file"
+            className="form-control"
+            multiple
+            accept=".jpg,.jpeg,.png,.webp,.pdf"
+            onChange={handleFilesSelected}
+          />
+          {attachments.length > 0 && (
+            <ul className="list-unstyled mt-2">
+              {attachments.map((row, index) => (
+                <li key={`${row.file.name}-${index}`} className="d-flex align-items-center gap-2 py-1">
+                  <span className="badge text-bg-secondary">{fileTypeLabel(row.file)}</span>
+                  <span>{row.file.name}</span>
+                  <span className="text-muted">({formatFileSize(row.file.size)})</span>
+                  {row.error && <span className="tt-inline-error">{row.error}</span>}
+                  <button
+                    type="button"
+                    className="btn btn-tt-tertiary btn-sm ms-auto"
+                    onClick={() => removeAttachment(index)}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          className={`btn btn-tt-primary${submitting ? ' tt-busy' : ''}`}
+          disabled={submitting}
+          aria-busy={submitting}
+        >
+          {submitting && <span className="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>}
+          {submitting ? 'Submitting…' : 'Submit'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/CreateTicket.tsx
+++ b/client/src/pages/CreateTicket.tsx
@@ -13,6 +13,7 @@ type RequestedPriority = (typeof REQUESTED_PRIORITIES)[number];
 
 const ALLOWED_ATTACHMENT_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
 const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+const MAX_ATTACHMENT_COUNT = 5;
 
 interface AttachmentRow {
   file: File;
@@ -91,6 +92,8 @@ export function CreateTicket() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [successTicketNumber, setSuccessTicketNumber] = useState<string | null>(null);
 
+  const [serverFieldErrors, setServerFieldErrors] = useState<FieldErrors>({});
+
   const [attachments, setAttachments] = useState<AttachmentRow[]>([]);
 
   useEffect(() => {
@@ -125,7 +128,9 @@ export function CreateTicket() {
     };
   }, []);
 
-  const errors = validate(values);
+  // Server errors are spread last: the backend is the authority, and it knows things the
+  // client cannot, such as a Category deactivated after this page loaded (api-spec.md 1).
+  const errors: FieldErrors = { ...validate(values), ...serverFieldErrors };
 
   const showError = (field: FieldName) => Boolean((touched[field] || submitAttempted) && errors[field]);
 
@@ -133,6 +138,14 @@ export function CreateTicket() {
     (field: FieldName) =>
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
       setValues((prev) => ({ ...prev, [field]: event.target.value }));
+      // Drop this field's server-side rejection once the user edits it; a stale message on a
+      // field they have already corrected is worse than none.
+      setServerFieldErrors((prev) => {
+        if (!(field in prev)) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
     };
 
   const handleBlur = (field: FieldName) => () => {
@@ -143,6 +156,9 @@ export function CreateTicket() {
     const files = event.target.files;
     if (!files) return;
 
+    // Checks run in BR-27's order - type, then size, then the per-Ticket count - so the picker
+    // and the server reject a file for the same reason in the same priority.
+    let validCount = attachments.filter((row) => row.error === null).length;
     const nextRows: AttachmentRow[] = Array.from(files).map((file) => {
       if (!ALLOWED_ATTACHMENT_TYPES.includes(file.type)) {
         return { file, error: 'File type not allowed. Use JPG, PNG, WEBP, or PDF.' };
@@ -150,6 +166,10 @@ export function CreateTicket() {
       if (file.size > MAX_ATTACHMENT_BYTES) {
         return { file, error: 'File is over the 5 MB limit.' };
       }
+      if (validCount >= MAX_ATTACHMENT_COUNT) {
+        return { file, error: 'Only 5 attachments are allowed per Ticket (BR-15).' };
+      }
+      validCount += 1;
       return { file, error: null };
     });
 
@@ -165,6 +185,7 @@ export function CreateTicket() {
     event.preventDefault();
     setSubmitAttempted(true);
     setSubmitError(null);
+    setServerFieldErrors({});
 
     if (Object.keys(errors).length > 0) {
       return;
@@ -190,7 +211,32 @@ export function CreateTicket() {
       });
 
       if (!response.ok) {
-        throw new Error('Backend returned an error');
+        // A 500 can return HTML rather than JSON; without this guard the parse would throw and
+        // land in the catch below, reporting a network failure for a server-side rejection.
+        const body = await response.json().catch(() => null);
+        const fields = body?.error?.fields;
+
+        // Only VALIDATION_ERROR carries `fields` (api-spec.md 1). Map them onto the form so the
+        // user sees which fields to fix, rather than a generic banner (AC-09, AC-10).
+        if (response.status === 400 && Array.isArray(fields) && fields.length > 0) {
+          setServerFieldErrors(
+            Object.fromEntries(
+              fields
+                .filter((item: { field?: string; message?: string }) => item.field && item.message)
+                .map((item: { field: string; message: string }) => [item.field, item.message]),
+            ) as FieldErrors,
+          );
+          setSubmitError('The server rejected some fields. Please correct them and submit again.');
+          return;
+        }
+
+        // No field to attach it to - e.g. 404 REQUESTER_NOT_FOUND when the selected Requester was
+        // deactivated after selection. Show the server's own message so the cause is visible.
+        setSubmitError(
+          body?.error?.message ??
+            'The server rejected the request. Your entered values have been kept - please try again.',
+        );
+        return;
       }
 
       const created = await response.json();
@@ -220,6 +266,11 @@ export function CreateTicket() {
           <p className="mb-0">
             <strong>Ticket Number:</strong> {successTicketNumber}
           </p>
+          {attachments.length > 0 && (
+            <p className="mb-0 mt-2">
+              Selected files were not uploaded - attachment upload is not part of this release.
+            </p>
+          )}
         </div>
         <button type="button" className="btn btn-tt-primary" onClick={handleCreateAnother}>
           Create Another Ticket
@@ -239,9 +290,22 @@ export function CreateTicket() {
       )}
 
       <form noValidate onSubmit={handleSubmit}>
-        <div className="mb-3">
-          <label className="form-label">Requester</label>
-          <input type="text" className="form-control tt-field-readonly" value={requester?.name ?? ''} readOnly />
+        {/* ui-spec.md 8: system-generated and read-only fields sit in a row at the top on
+            desktop and tablet, stacking below 768px. Ticket Number and Ticket Date are assigned
+            by the server on creation (BR-04), so before submission there is nothing to show. */}
+        <div className="row mb-3">
+          <div className="col-12 col-md-4">
+            <label className="form-label">Requester</label>
+            <input type="text" className="form-control tt-field-readonly" value={requester?.name ?? ''} readOnly />
+          </div>
+          <div className="col-12 col-md-4">
+            <label className="form-label">Ticket Number</label>
+            <input type="text" className="form-control tt-field-readonly" value="Generated on submit" readOnly />
+          </div>
+          <div className="col-12 col-md-4">
+            <label className="form-label">Ticket Date</label>
+            <input type="text" className="form-control tt-field-readonly" value="Set by the server on submit" readOnly />
+          </div>
         </div>
 
         <div className="mb-3">
@@ -367,6 +431,10 @@ export function CreateTicket() {
             accept=".jpg,.jpeg,.png,.webp,.pdf"
             onChange={handleFilesSelected}
           />
+          <div className="form-text">
+            Selected files are checked for type and size now. Attachment upload is not part of this
+            release, so they are not sent with this Ticket yet.
+          </div>
           {attachments.length > 0 && (
             <ul className="list-unstyled mt-2">
               {attachments.map((row, index) => (

--- a/client/src/theme.css
+++ b/client/src/theme.css
@@ -62,3 +62,25 @@ body {
   border-color: var(--tt-secondary) !important;
   box-shadow: 0 0 0 2px var(--tt-secondary) !important;
 }
+
+/* Issue #13 additions — ui-spec.md §4 (required-field marker), §18 (read-only fields,
+   busy button state). */
+
+.tt-required::after {
+  content: " *";
+  color: var(--tt-error-text);
+}
+
+.tt-field-readonly {
+  background: var(--tt-readonly-bg);
+  color: var(--tt-text);
+}
+
+.tt-busy {
+  cursor: progress;
+}
+
+.tt-inline-error {
+  color: var(--tt-error-text);
+  font-size: 0.875rem;
+}

--- a/client/src/theme.css
+++ b/client/src/theme.css
@@ -48,6 +48,19 @@ body {
   color: var(--tt-secondary);
 }
 
+/* ui-spec.md 18: tertiary button is text-only, #0B7A46 (--tt-secondary). */
+.btn-tt-tertiary {
+  background: transparent;
+  border-color: transparent;
+  color: var(--tt-secondary);
+}
+.btn-tt-tertiary:hover,
+.btn-tt-tertiary:focus {
+  background: var(--tt-pale);
+  border-color: transparent;
+  color: var(--tt-secondary);
+}
+
 .tt-alert-error {
   color: var(--tt-error-text);
   background: var(--tt-error-bg);

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { RequesterProvider } from '../../src/context/RequesterContext';
+import { CreateTicket } from '../../src/pages/CreateTicket';
+
+const STORAGE_KEY = 'toktickit.selectedRequester';
+
+function selectStoredRequester() {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ id: 1, name: 'Anong Srisai' }));
+}
+
+function mockReferenceDataFetch() {
+  return vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/categories')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [{ id: 1, name: 'Hardware' }],
+      } as Response);
+    }
+    if (url.includes('/api/related-systems')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [{ id: 1, name: 'Campus Wi-Fi' }],
+      } as Response);
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/category/i), { target: { value: '1' } });
+  fireEvent.change(screen.getByLabelText(/related system/i), { target: { value: '1' } });
+  fireEvent.change(screen.getByLabelText(/summary/i), {
+    target: { value: 'Laptop battery drains quickly' },
+  });
+  fireEvent.change(screen.getByLabelText(/description/i), {
+    target: { value: 'Battery drops from 100% to 20% within two hours of normal use.' },
+  });
+  fireEvent.change(screen.getByLabelText(/requested priority/i), { target: { value: 'MEDIUM' } });
+}
+
+function renderCreateTicket() {
+  return render(
+    <MemoryRouter>
+      <RequesterProvider>
+        <CreateTicket />
+      </RequesterProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('CreateTicket', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('shows a loading placeholder on the dropdowns while reference data loads', () => {
+    selectStoredRequester();
+    vi.spyOn(global, 'fetch').mockReturnValue(new Promise(() => {}));
+
+    renderCreateTicket();
+
+    expect(screen.getAllByText(/loading…/i).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/category/i)).toBeDisabled();
+  });
+
+  it('shows a safe error when reference data fails to load', async () => {
+    selectStoredRequester();
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+    renderCreateTicket();
+
+    await waitFor(() => {
+      expect(screen.getByText(/unable to load categories or related systems/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows field-level validation messages on submit and makes no ticket-creation call', async () => {
+    selectStoredRequester();
+    const fetchSpy = mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(await screen.findByText(/category is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/summary must be 5-120 characters/i)).toBeInTheDocument();
+
+    // Only the two reference-data GETs on mount — validation blocked the POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows Submit in a busy, disabled state while the request is in flight', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+    fillValidForm();
+
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/tickets')) {
+        return new Promise(() => {}); // never resolves — holds the busy state on screen
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(await screen.findByRole('button', { name: /submitting/i })).toBeDisabled();
+  });
+
+  it('shows a safe error and keeps entered values when the backend is unreachable', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+    fillValidForm();
+
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/tickets')) {
+        return Promise.reject(new Error('backend down'));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unable to reach the server/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/summary/i)).toHaveValue('Laptop battery drains quickly');
+  });
+
+  it('shows the backend-generated Ticket Number on success', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+    fillValidForm();
+
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/tickets')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ ticketNumber: 'TKT-2026-000001' }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(await screen.findByText(/TKT-2026-000001/)).toBeInTheDocument();
+  });
+
+  it('rejects an oversized attachment with an inline message', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+
+    const bigFile = new File([new Uint8Array(6 * 1024 * 1024)], 'photo.png', { type: 'image/png' });
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files: [bigFile] } });
+
+    expect(await screen.findByText(/over the 5 mb limit/i)).toBeInTheDocument();
+  });
+
+  it('rejects a disallowed file type with an inline message', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+
+    const badFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files: [badFile] } });
+
+    expect(await screen.findByText(/file type not allowed/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -190,4 +190,85 @@ describe('CreateTicket', () => {
 
     expect(await screen.findByText(/file type not allowed/i)).toBeInTheDocument();
   });
+
+  it('maps a 400 error.fields response onto the matching form fields (AC-09, AC-10)', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+    fillValidForm();
+
+    vi.restoreAllMocks();
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/tickets')) {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: async () => ({
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'One or more fields are invalid',
+              fields: [
+                { field: 'categoryId', message: 'categoryId must reference an active category' },
+              ],
+            },
+          }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    // The server's own field message is shown, not the generic network banner.
+    expect(
+      await screen.findByText(/categoryid must reference an active category/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/unable to reach the server/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the server message when a rejection has no matching field (404)', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+    fillValidForm();
+
+    vi.restoreAllMocks();
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/tickets')) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          json: async () => ({
+            error: { code: 'REQUESTER_NOT_FOUND', message: 'Requester not found or inactive' },
+          }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(await screen.findByText(/requester not found or inactive/i)).toBeInTheDocument();
+  });
+
+  it('rejects a sixth attachment once five valid files are selected (BR-15)', async () => {
+    selectStoredRequester();
+    mockReferenceDataFetch();
+
+    renderCreateTicket();
+    await waitFor(() => expect(screen.getByLabelText(/category/i)).toBeEnabled());
+
+    const files = Array.from({ length: 6 }, (_, i) =>
+      new File(['x'], `shot-${i}.png`, { type: 'image/png' }),
+    );
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files } });
+
+    expect(await screen.findByText(/only 5 attachments are allowed/i)).toBeInTheDocument();
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from './prisma';
+import { formatTicketNumber, validateTicketText } from './ticket-helpers';
 
 const app = express();
 app.use(express.json());
@@ -93,15 +94,8 @@ app.post('/api/tickets', async (req, res) => {
         }
     }
 
-    const trimmedSummary = typeof summary === 'string' ? summary.trim() : '';
-    if (trimmedSummary.length < 5 || trimmedSummary.length > 120) {
-        fields.push({ field: 'summary', message: 'summary must be 5-120 characters' });
-    }
-
-    const trimmedDescription = typeof description === 'string' ? description.trim() : '';
-    if (trimmedDescription.length < 10 || trimmedDescription.length > 2000) {
-        fields.push({ field: 'description', message: 'description must be 10-2000 characters' });
-    }
+    const text = validateTicketText(summary, description);
+    fields.push(...text.errors);
 
     if (!REQUESTED_PRIORITIES.includes(requestedPriority)) {
         fields.push({ field: 'requestedPriority', message: 'requestedPriority must be LOW, MEDIUM, or HIGH' });
@@ -114,7 +108,7 @@ app.post('/api/tickets', async (req, res) => {
     }
 
     const [{ nextval }] = await prisma.$queryRaw<{ nextval: bigint }[]>`SELECT nextval('ticket_number_seq') AS nextval`;
-    const ticketNumber = `TKT-${new Date().getFullYear()}-${String(nextval).padStart(6, '0')}`;
+    const ticketNumber = formatTicketNumber(new Date().getFullYear(), nextval);
 
     const ticket = await prisma.ticket.create({
       data: {
@@ -122,8 +116,8 @@ app.post('/api/tickets', async (req, res) => {
         requesterId,
         categoryId,
         relatedSystemId,
-        summary: trimmedSummary,
-        description: trimmedDescription,
+        summary: text.summary,
+        description: text.description,
         requestedPriority,
       },
       select: {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { prisma } from './prisma';
 
 const app = express();
+app.use(express.json());
 
 app.get('/api/health', (req, res) => {
     res.status(200).json({
@@ -19,7 +20,7 @@ app.get('/api/categories', async (req, res) => {
         });
         res.status(200).json(categories);
     } catch (error) {
-        res.status(500).json({ error: 'Unable to retrieve categories' });
+        res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Unable to retrieve categories' } });
     }
 });
 
@@ -32,8 +33,118 @@ app.get('/api/requesters', async (req, res) => {
         });
         res.status(200).json(requesters);
     } catch (error) {
-        res.status(500).json({ error: 'Unable to retrieve requesters' });
+        res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Unable to retrieve requesters' } });
     }
+});
+
+app.get('/api/related-systems', async (req, res) => {
+    try {
+        const relatedSystems = await prisma.relatedSystem.findMany({
+            where: { isActive: true },
+            orderBy: { id: 'asc' },
+            select: { id: true, name: true },
+        });
+        res.status(200).json(relatedSystems);
+    } catch (error) {
+        res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Unable to retrieve related systems' } });
+    }
+});
+
+const REQUESTED_PRIORITIES = ['LOW', 'MEDIUM', 'HIGH'];
+
+app.post('/api/tickets', async (req, res) => {
+  try {
+    const { requesterId, categoryId, relatedSystemId, summary, description, requestedPriority } = req.body;
+
+    if (typeof requesterId !== 'number') {
+        return res.status(400).json({
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'requesterId is required',
+                fields: [{ field: 'requesterId', message: 'requesterId is required' }],
+            },
+        });
+    }
+
+    const requester = await prisma.requester.findUnique({ where: { id: requesterId } });
+    if (!requester || !requester.isActive) {
+        return res.status(404).json({
+            error: { code: 'REQUESTER_NOT_FOUND', message: 'Requester not found or inactive' },
+        });
+    }
+
+    const fields: { field: string; message: string }[] = [];
+
+    if (typeof categoryId !== 'number') {
+        fields.push({ field: 'categoryId', message: 'categoryId is required' });
+    } else {
+        const category = await prisma.category.findUnique({ where: { id: categoryId } });
+        if (!category || !category.isActive) {
+            fields.push({ field: 'categoryId', message: 'categoryId must reference an active category' });
+        }
+    }
+
+    if (typeof relatedSystemId !== 'number') {
+        fields.push({ field: 'relatedSystemId', message: 'relatedSystemId is required' });
+    } else {
+        const relatedSystem = await prisma.relatedSystem.findUnique({ where: { id: relatedSystemId } });
+        if (!relatedSystem || !relatedSystem.isActive) {
+            fields.push({ field: 'relatedSystemId', message: 'relatedSystemId must reference an active related system' });
+        }
+    }
+
+    const trimmedSummary = typeof summary === 'string' ? summary.trim() : '';
+    if (trimmedSummary.length < 5 || trimmedSummary.length > 120) {
+        fields.push({ field: 'summary', message: 'summary must be 5-120 characters' });
+    }
+
+    const trimmedDescription = typeof description === 'string' ? description.trim() : '';
+    if (trimmedDescription.length < 10 || trimmedDescription.length > 2000) {
+        fields.push({ field: 'description', message: 'description must be 10-2000 characters' });
+    }
+
+    if (!REQUESTED_PRIORITIES.includes(requestedPriority)) {
+        fields.push({ field: 'requestedPriority', message: 'requestedPriority must be LOW, MEDIUM, or HIGH' });
+    }
+
+    if (fields.length > 0) {
+        return res.status(400).json({
+            error: { code: 'VALIDATION_ERROR', message: 'One or more fields are invalid', fields },
+        });
+    }
+
+    const [{ nextval }] = await prisma.$queryRaw<{ nextval: bigint }[]>`SELECT nextval('ticket_number_seq') AS nextval`;
+    const ticketNumber = `TKT-${new Date().getFullYear()}-${String(nextval).padStart(6, '0')}`;
+
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber,
+        requesterId,
+        categoryId,
+        relatedSystemId,
+        summary: trimmedSummary,
+        description: trimmedDescription,
+        requestedPriority,
+      },
+      select: {
+        id: true,
+        ticketNumber: true,
+        ticketDate: true,
+        requesterId: true,
+        categoryId: true,
+        relatedSystemId: true,
+        summary: true,
+        description: true,
+        requestedPriority: true,
+        currentStatus: true,
+      },
+    });
+
+    res.status(201).json(ticket);
+  } catch (error) {
+    console.error('POST /api/tickets failed:', error);
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Unable to create ticket' } });
+  }
 });
 
 export default app;

--- a/server/src/ticket-helpers.ts
+++ b/server/src/ticket-helpers.ts
@@ -1,0 +1,24 @@
+export type FieldError = { field: string; message: string };
+
+export function formatTicketNumber(year: number, sequence: number | bigint): string {
+  return `TKT-${year}-${String(sequence).padStart(6, '0')}`;
+}
+
+export function validateTicketText(
+  summary: unknown,
+  description: unknown,
+): { summary: string; description: string; errors: FieldError[] } {
+  const errors: FieldError[] = [];
+
+  const trimmedSummary = typeof summary === 'string' ? summary.trim() : '';
+  if (trimmedSummary.length < 5 || trimmedSummary.length > 120) {
+    errors.push({ field: 'summary', message: 'summary must be 5-120 characters' });
+  }
+
+  const trimmedDescription = typeof description === 'string' ? description.trim() : '';
+  if (trimmedDescription.length < 10 || trimmedDescription.length > 2000) {
+    errors.push({ field: 'description', message: 'description must be 10-2000 characters' });
+  }
+
+  return { summary: trimmedSummary, description: trimmedDescription, errors };
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+import app from '../../src/app';
+import { prisma } from '../../src/prisma';
+
+describe('POST /api/tickets', () => {
+  let activeRequesterId: number;
+  let inactiveRequesterId: number;
+  let activeCategoryId: number;
+  let activeRelatedSystemId: number;
+
+  const validBody = () => ({
+    requesterId: activeRequesterId,
+    categoryId: activeCategoryId,
+    relatedSystemId: activeRelatedSystemId,
+    summary: 'Laptop battery drains quickly',
+    description: 'Battery drops from 100% to 20% within two hours of normal use.',
+    requestedPriority: 'MEDIUM',
+  });
+
+  beforeAll(async () => {
+    const activeRequester = await prisma.requester.findFirst({ where: { isActive: true } });
+    const inactiveRequester = await prisma.requester.findFirst({ where: { isActive: false } });
+    const category = await prisma.category.findFirst({ where: { isActive: true } });
+    const relatedSystem = await prisma.relatedSystem.findFirst({ where: { isActive: true } });
+
+    activeRequesterId = activeRequester!.id;
+    inactiveRequesterId = inactiveRequester!.id;
+    activeCategoryId = category!.id;
+    activeRelatedSystemId = relatedSystem!.id;
+  });
+
+  it('creates a Ticket owned by the given Requester, starting with status New', async () => {
+    const response = await request(app).post('/api/tickets').send(validBody());
+
+    expect(response.status).toBe(201);
+    expect(response.body.requesterId).toBe(activeRequesterId);
+    expect(response.body.currentStatus).toBe('NEW');
+    expect(response.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+  });
+
+  it('generates a unique Ticket Number for each Ticket', async () => {
+    const first = await request(app).post('/api/tickets').send(validBody());
+    const second = await request(app).post('/api/tickets').send(validBody());
+
+    expect(first.body.ticketNumber).not.toBe(second.body.ticketNumber);
+  });
+
+  it('rejects a missing summary with a field-level message and no Ticket created', async () => {
+    const response = await request(app)
+      .post('/api/tickets')
+      .send({ ...validBody(), summary: '' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    expect(response.body.error.fields).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: 'summary' })]),
+    );
+  });
+
+  it('reports every failing field at once, not just the first', async () => {
+    const response = await request(app)
+      .post('/api/tickets')
+      .send({ ...validBody(), summary: '', description: 'x', requestedPriority: 'URGENT' });
+
+    expect(response.status).toBe(400);
+    const failingFields = response.body.error.fields.map((f: { field: string }) => f.field);
+    expect(failingFields).toEqual(
+      expect.arrayContaining(['summary', 'description', 'requestedPriority']),
+    );
+  });
+
+  it('rejects an unknown requesterId with 404 REQUESTER_NOT_FOUND', async () => {
+    const response = await request(app)
+      .post('/api/tickets')
+      .send({ ...validBody(), requesterId: 999999 });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error.code).toBe('REQUESTER_NOT_FOUND');
+  });
+
+  it('rejects an inactive Requester with 404 REQUESTER_NOT_FOUND', async () => {
+    const response = await request(app)
+      .post('/api/tickets')
+      .send({ ...validBody(), requesterId: inactiveRequesterId });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error.code).toBe('REQUESTER_NOT_FOUND');
+  });
+
+  it('never accepts a client-supplied ticketNumber or ticketDate', async () => {
+    const response = await request(app)
+      .post('/api/tickets')
+      .send({
+        ...validBody(),
+        ticketNumber: 'TKT-0000-000000',
+        ticketDate: '2000-01-01T00:00:00Z',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.ticketNumber).not.toBe('TKT-0000-000000');
+  });
+});
+
+describe('GET /api/related-systems', () => {
+  it('returns only the active seeded Related Systems', async () => {
+    const response = await request(app).get('/api/related-systems');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveLength(6);
+    response.body.forEach((relatedSystem: { id: number; name: string }) => {
+      expect(typeof relatedSystem.id).toBe('number');
+      expect(typeof relatedSystem.name).toBe('string');
+    });
+  });
+});

--- a/server/tests/lab-02/ticket-field-validation.unit.test.ts
+++ b/server/tests/lab-02/ticket-field-validation.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { validateTicketText } from '../../src/ticket-helpers';
+
+const valid = (n: number) => 'a'.repeat(n);
+
+describe('validateTicketText (UNIT-03, BR-11)', () => {
+  it('trims surrounding whitespace from both fields', () => {
+    const result = validateTicketText('  Printer broken  ', '  The office printer jams.  ');
+    expect(result.summary).toBe('Printer broken');
+    expect(result.description).toBe('The office printer jams.');
+    expect(result.errors).toEqual([]);
+  });
+
+  it('accepts summary at both boundaries (5 and 120)', () => {
+    expect(validateTicketText(valid(5), valid(10)).errors).toEqual([]);
+    expect(validateTicketText(valid(120), valid(10)).errors).toEqual([]);
+  });
+
+  it('rejects summary just outside the boundaries (4 and 121)', () => {
+    expect(validateTicketText(valid(4), valid(10)).errors).toEqual([
+      { field: 'summary', message: 'summary must be 5-120 characters' },
+    ]);
+    expect(validateTicketText(valid(121), valid(10)).errors).toEqual([
+      { field: 'summary', message: 'summary must be 5-120 characters' },
+    ]);
+  });
+
+  it('accepts description at both boundaries (10 and 2000) and rejects just outside', () => {
+    expect(validateTicketText(valid(5), valid(10)).errors).toEqual([]);
+    expect(validateTicketText(valid(5), valid(2000)).errors).toEqual([]);
+    expect(validateTicketText(valid(5), valid(9)).errors).toEqual([
+      { field: 'description', message: 'description must be 10-2000 characters' },
+    ]);
+    expect(validateTicketText(valid(5), valid(2001)).errors).toEqual([
+      { field: 'description', message: 'description must be 10-2000 characters' },
+    ]);
+  });
+
+  it('treats a whitespace-only value as empty and rejects it', () => {
+    const result = validateTicketText('     ', valid(10));
+    expect(result.summary).toBe('');
+    expect(result.errors).toEqual([
+      { field: 'summary', message: 'summary must be 5-120 characters' },
+    ]);
+  });
+
+  it('rejects non-string values without throwing', () => {
+    expect(() => validateTicketText(undefined, 42)).not.toThrow();
+    expect(validateTicketText(undefined, 42).errors).toEqual([
+      { field: 'summary', message: 'summary must be 5-120 characters' },
+      { field: 'description', message: 'description must be 10-2000 characters' },
+    ]);
+  });
+
+  it('returns both errors together when both fields are invalid', () => {
+    const result = validateTicketText('abc', 'short');
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.map((e) => e.field)).toEqual(['summary', 'description']);
+  });
+});

--- a/server/tests/lab-02/ticket-number-generator.unit.test.ts
+++ b/server/tests/lab-02/ticket-number-generator.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatTicketNumber } from '../../src/ticket-helpers';
+
+describe('formatTicketNumber (UNIT-01, BR-01/FR-05)', () => {
+  it('formats a sequence number as TKT-<year>-<6 digits>', () => {
+    expect(formatTicketNumber(2026, 42)).toBe('TKT-2026-000042');
+  });
+
+  it('pads a single-digit sequence to six digits', () => {
+    expect(formatTicketNumber(2026, 1)).toBe('TKT-2026-000001');
+  });
+
+  it('accepts the bigint the database sequence returns', () => {
+    expect(formatTicketNumber(2026, 42n)).toBe('TKT-2026-000042');
+  });
+
+  it('uses the year it is given rather than the current year', () => {
+    expect(formatTicketNumber(2027, 1)).toBe('TKT-2027-000001');
+  });
+
+  it('grows past six digits instead of truncating', () => {
+    expect(formatTicketNumber(2026, 1234567)).toBe('TKT-2026-1234567');
+  });
+});


### PR DESCRIPTION
"Closes #13

- Add POST /api/tickets with full validation (requesterId 400/404 split, batched field errors for the rest)
- Add GET /api/related-systems
- Create Ticket screen: client-side validation, busy/success/error states, attachment type+size checks (upload itself deferred to Issue #16)
- Fix categories/requesters error envelope to match api-spec.md
- Server + client tests for all of the above"