### PR TITLE
docs: add BR-26/27/28 and AC-28/29, attachment validation precedence, Last Updated column

### DIFF
--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -218,8 +218,8 @@ Requires `X-Requester-Id`, must own the parent Ticket. Body:
 { "reason": "Wrong file attached by mistake" }
 ```
 `reason` required, non-empty (BR-17). Sets `isActive: false`, `removedAt` to now, stores
-`removalReason`. The database row is never deleted (BR-16). Response `200` with the updated
-metadata shape. `404 NOT_FOUND` if the attachment is missing or already removed.
+`removalReason`. The database row is never deleted (BR-16). Soft removal also updates the parent
+Ticket's `updatedAt` (BR-28), the same as upload. Response `200` with the updated metadata shape. `404 NOT_FOUND` if the attachment is missing or already removed.
 `403 FORBIDDEN` if it exists and is active but is not owned by the requesting Requester.
 `400 VALIDATION_ERROR` if `reason` is missing or blank.
 

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -128,7 +128,7 @@ different Requester (§1).
 | `relatedSystem` | Related System id | none |
 | `currentStatus` | exact match | none |
 | `requestedPriority` | exact match | none |
-| `sort` | one of `ticketDate`, `ticketNumber`, `requestedPriority`, `currentStatus` | `ticketDate` |
+| `sort` | one of `ticketDate`, `ticketNumber`, `requestedPriority`, `currentStatus`, `updatedAt` | `ticketDate` |
 | `order` | `asc` or `desc` | `desc` |
 | `page` | 1-based page number | `1` |
 | `pageSize` | one of `5`, `10`, `20` | `10` |
@@ -179,13 +179,23 @@ it is an internal detail.
 
 Requires `X-Requester-Id`, must own the Ticket. `multipart/form-data` with one `file` field.
 
-Validation:
-- Ticket must exist → `404 NOT_FOUND`; must be owned by the requesting Requester → `403 FORBIDDEN`
-- file type must be JPG, JPEG, PNG, WEBP or PDF → `415 UNSUPPORTED_MEDIA_TYPE`
-- file size must be ≤ 5 MB → `413 PAYLOAD_TOO_LARGE`
-- the Ticket must have fewer than 5 currently active attachments → `409 ATTACHMENT_LIMIT_REACHED`
+Validation. These checks run in this order and the **first** failure determines the single
+response status (BR-27); no later check is evaluated, and exactly one error is returned per
+upload:
 
-Response `201`: the metadata shape above, `isActive: true`.
+1. Ticket must exist → `404 NOT_FOUND`
+2. Ticket must be owned by the requesting Requester → `403 FORBIDDEN`
+3. file type must be JPG, JPEG, PNG, WEBP or PDF → `415 UNSUPPORTED_MEDIA_TYPE`
+4. file size must be ≤ 5 MB → `413 PAYLOAD_TOO_LARGE`
+5. the Ticket must have fewer than 5 currently active attachments → `409 ATTACHMENT_LIMIT_REACHED`
+
+Existence and ownership are settled before the file is examined, so a rejection never reveals
+whether another Requester's Ticket exists; the two intrinsic file checks precede the one that
+needs a database count.
+
+Response `201`: the metadata shape above, `isActive: true`. If the database write fails after the
+file has been stored, the stored file is deleted before the error is returned, so no orphaned file
+is left behind (BR-26). A successful upload updates the parent Ticket's `updatedAt` (BR-28).
 
 ### `GET /api/attachments/:id` — metadata
 

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -19,6 +19,7 @@ Pull Requests I authored (reviewed by my partner):
 | [#19](https://github.com/ShitheadQuin/Toktickit/pull/19) | feature/10-lab2-spec | lab2-staging | Requested changes (5 points), fix pushed, re-request sent — approved, merged into lab2-staging |
 | [#20](https://github.com/ShitheadQuin/Toktickit/pull/20) | feature/11-data-seed | lab2-staging | Requested changes (2 points), fix pushed, approved, merged into lab2-staging |
 | [#21](https://github.com/ShitheadQuin/Toktickit/pull/21) | feature/12-requester-context | lab2-staging | Requested changes (3 points), fixes pushed, approved, merged into lab2-staging |
+| [#23](https://github.com/ShitheadQuin/Toktickit/pull/23) | feature/spec-attachment-rules | lab2-staging | Requested changes (2 points), fixes pushed, re-request sent |
 
 ### Issue 10 — [ShitheadQuin/Toktickit#19](https://github.com/ShitheadQuin/Toktickit/pull/19)
 
@@ -102,3 +103,47 @@ work has a clear formal owner. Item 3 (minor) acknowledged as worth doing once `
 exist; deferred to whichever Issue introduces them, no code change needed yet. Retook all six
 Issue #12 screenshots after the styling fix so evidence matches the final UI, not the pre-fix
 version. Chanat approved after the fixes; PR #21 merged into `lab2-staging`.
+
+### Issue 24 — [ShitheadQuin/Toktickit#23](https://github.com/ShitheadQuin/Toktickit/pull/23)
+
+Documentation-only PR adding the attachment business rules labsheet §4.5 requires (BR-26, BR-27),
+the optional BR-28, acceptance criteria AC-28/AC-29, and the My Tickets Last Updated column.
+
+**Chanat's comments (requested changes):**
+1. `DELETE /api/attachments/:id` does not mention the `updatedAt` bump. BR-28 covers both upload
+   and soft removal, and `POST /api/tickets/:id/attachments` states it, but the DELETE section
+   does not. API-21 tests both actions, so the contract should say both.
+2. The Last Updated column was added to the desktop table but not to the mobile card, and not to
+   the sort control. `api-spec.md` §4 now accepts `sort=updatedAt`; if the UI cannot reach it, the
+   sort value has no user path. Asked whether the sort control exposes it.
+
+**Chanat's verification (no change requested):** confirmed BR-26 writes the file before the
+database row and deletes it on a failed write, and correctly limits compensation to the upload
+rather than the Ticket per BR-19; confirmed BR-27's order settles existence and ownership before
+the file checks so a rejection cannot leak another Requester's Ticket, and that `api-spec.md` §5
+repeats the same five steps; confirmed AC-28 and AC-29 both map to tests and BR-28 has API-21.
+
+**My response:** Both points accepted — neither needed arguing, and both were real gaps rather
+than preference.
+
+Point 1 was a plain omission: the `updatedAt` sentence was written into the upload endpoint and
+not the removal one, even though BR-28 and API-21 both cover removal. Added to the DELETE section
+in `api-spec.md`.
+
+Point 2 was the more useful catch. `sort=updatedAt` had been added to the API contract without
+anything in `ui-spec.md` saying the user could select it — a permitted API value with no user
+path, exactly as described. Fixed by naming the sort control's options explicitly in §11 (Ticket
+Date, Last Updated, Ticket Number, Requested Priority, Current Status, ascending or descending,
+default Ticket Date descending per BR-10) and stating that every permitted API sort value is
+reachable from the UI. This follows the pattern §11 already used for page size, which is
+explicitly documented as *not* exposed — so the spec now says plainly, in both directions, what
+the UI does and does not offer.
+
+The mobile card was a real consequence of point 2 rather than a separate nit: once Last Updated
+is sortable, a phone user sorting by it would see an order the card does not explain. Added it as
+its own muted line beneath the secondary line rather than as a fourth item on that line, because
+four items wrap at narrow widths and AC-25 fails on clipped or overlapping content — the reason
+is written into §11 so the choice is documented rather than arbitrary.
+
+No code changed in this PR; Issue #14 implements the column and the sort control, Issue #16
+implements BR-26/27/28.

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -118,6 +118,25 @@ work is a foundation rather than three isolated pages.
   collisions.
 - BR-25: Each attachment record stores original filename, stored filename, MIME type, size in
   bytes, uploaded timestamp, and, once removed, removed timestamp and removal reason.
+- BR-26: An attachment's stored file and its database record are created together or not at all.
+  The file is written to disk first; if the subsequent database write fails, the written file is
+  deleted before the error is returned. No stored file may exist without a matching Attachment
+  row, and no Attachment row may exist without its stored file. This compensation applies to the
+  failing upload only - per BR-19 the parent Ticket is never rolled back for an attachment
+  failure.
+- BR-27: When one uploaded file fails more than one validation check, the checks are evaluated in
+  this fixed order, and the first failure alone determines the response. No later check is
+  evaluated, and exactly one error is returned per upload:
+  (1) the Ticket exists (404 NOT_FOUND); (2) the Ticket is owned by the requesting Requester
+  (403 FORBIDDEN); (3) the file type is JPG, JPEG, PNG, WEBP or PDF (415 UNSUPPORTED_MEDIA_TYPE);
+  (4) the file size is 5 MB or less (413 PAYLOAD_TOO_LARGE); (5) the Ticket has fewer than 5
+  currently active attachments (409 ATTACHMENT_LIMIT_REACHED). Existence and ownership are
+  settled before the file itself is discussed, so a rejection never reveals whether another
+  Requester's Ticket exists. The Create Ticket screen's local picker applies the same
+  type-then-size order, so the client and server never disagree about which rule a file broke.
+- BR-28: Uploading an attachment or soft-removing one updates the parent Ticket's last-updated
+  timestamp. Attachment activity is Ticket activity, so a Ticket whose attachments changed is not
+  shown as stale in the Requester's list. Ticket Date is unaffected (BR-04).
 
 ## 6. UI Specification Summary
 
@@ -233,6 +252,12 @@ Full detail — request/response shapes, validation, pagination metadata, status
 - AC-27: Given a Requester is selected, when the Create Ticket screen loads, then the
   Requester field displays the selected Requester's name, and on successful submission the saved
   Ticket's `requesterId` matches the selected Requester.
+- AC-28: Given an owned Ticket, when a file is uploaded and the database write for its Attachment
+  record fails, then no stored file for that upload remains on disk, no Attachment row exists, and
+  the parent Ticket is unchanged.
+- AC-29: Given an owned Ticket, when a single upload violates more than one rule at once (for
+  example a 7 MB `.txt` file), then exactly one error is returned, and it is the earliest failing
+  check in BR-27's order - `415 UNSUPPORTED_MEDIA_TYPE` in that example, not `413`.
 
 ## 10. Definition of Done
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -12,12 +12,14 @@ PR, and that final run is the evidence submitted for Part 3.
 
 | Test ID | Type | Requirement / AC | What It Tests | Expected Result | Automated Test File | Final |
 |---|---|---|---|---|---|---|
-| UNIT-01 | Unit | BR-01, FR-05 | Ticket Number generator format and uniqueness | Matches `TKT-<year>-<6 digits>`; no collisions across a batch | `server/tests/lab-02/ticket-number-generator.unit.test.ts` | Planned |
+| UNIT-01 | Unit | BR-01, FR-05 | Ticket Number formatting helper, given a year and a sequence number | Matches `TKT-<year>-<6 digits>`, zero-padded; sequence uniqueness comes from the database sequence and is covered by API-01 | `server/tests/lab-02/ticket-number-generator.unit.test.ts` | Planned |
+| UNIT-02 | Unit | BR-27 | Attachment validation helper given a file failing several checks at once | Returns only the first failing check in BR-27's order | `server/tests/lab-02/attachment-validation.unit.test.ts` | Planned |
+| UNIT-03 | Unit | BR-11 | Summary/Description trim-and-length logic at its boundaries | Trimmed; 5-120 and 10-2000 enforced inclusively | `server/tests/lab-02/ticket-field-validation.unit.test.ts` | Planned |
 | API-01 | API | AC-01 | `POST /api/tickets` with valid data | 201; Ticket saved; Ticket Number returned in the correct format | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-02 | API | AC-09, AC-10 | `POST /api/tickets` with a missing or out-of-range field | 400 with every failing field listed | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | BR-04 | `POST /api/tickets` body includes client-supplied `ticketNumber`/`ticketDate`/`currentStatus` | Server-assigned values are used regardless | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-04 | API | AC-15, BR-08 | `GET /api/tickets` as Requester A, then as Requester B | Each response contains only that Requester's own Tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-05 | API | AC-18, AC-19, AC-20 | `GET /api/tickets` with search/filter/sort/page params | Correct subset, order, and pagination metadata | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-05 | API | AC-18, AC-19, AC-20 | `GET /api/tickets` with search/filter/sort/page params, including `sort=updatedAt` | Correct subset, order, and pagination metadata | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-06 | API | BR-10 | `GET /api/tickets` with an invalid `sort`/`page`/`pageSize` | Falls back to documented defaults, no error | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-07 | API | AC-16, AC-17 | `GET /api/tickets` for a Requester with none, and a non-matching search | 200, empty `data`, `totalItems: 0` in both cases | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-08 | API | AC-21 | `GET /api/tickets/:id` for an owned Ticket | 200 with full detail, including attachments | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
@@ -31,6 +33,9 @@ PR, and that final run is the evidence submitted for Part 3.
 | API-16 | API | BR-18 | Upload/remove an attachment on a Ticket not owned by the caller | 403 | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-17 | API | BR-19 | Ticket created successfully, a following attachment upload fails | Ticket remains saved; failure reported per-file, not rolled back | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-18 | API | AC-05, BR-06 | `GET /api/requesters` with an inactive Requester seeded | Inactive Requester excluded | `server/tests/lab-02/requesters.api.test.ts` | Planned |
+| API-19 | API | AC-28, BR-26 | Attachment database write fails after the file has been stored | Error returned; no orphaned file on disk; no Attachment row; Ticket unchanged | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-20 | API | AC-29, BR-27 | Upload one file that is both a disallowed type and over 5 MB | Single `415`; `413` not returned | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-21 | API | BR-28 | Upload then soft-remove an attachment, comparing the Ticket's `updatedAt` each time | Bumped by both actions; `ticketDate` unchanged | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | UI-01 | UI | AC-04, AC-05, AC-06 | RequesterSelector loading / empty / API-failure states | Correct state per condition; Continue disabled while loading | `client/tests/lab-02/RequesterSelector.test.tsx` | Planned |
 | UI-02 | UI | AC-26 | RequesterSelector keyboard-only navigation | Every control reachable and usable without a mouse | `client/tests/lab-02/RequesterSelector.test.tsx` | Planned |
 | UI-03 | UI | AC-02, AC-07, AC-08 | AppShell with no Requester, then after selecting/switching | Selector shown when none selected; name shown after; data reloads on switch | `client/tests/lab-02/AppShell.test.tsx` | Planned |
@@ -48,7 +53,7 @@ PR, and that final run is the evidence submitted for Part 3.
 | UI-15 | UI | AC-24 | AttachmentSection given a removed attachment | Download control absent/disabled for it | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | STYLE-01 | UI Style | ui-spec.md §18 | Required CSS classes, asterisks, field states, button states on Create Ticket | All required classes/attributes present as rendered | `e2e/lab-02/ui-style.spec.ts` | Planned |
 | STYLE-02 | UI Style | `ui-spec.md` §12 | Requested Priority and Current Status badge markup on My Tickets | Badge classes/colors match §12 for every value | `e2e/lab-02/ui-style.spec.ts` | Planned |
-| RESP-01 | Responsive | AC-25 | Screenshots of Create Ticket, My Tickets, Ticket Detail at desktop/tablet/mobile | No clipping, overlap, or unintended horizontal scroll at any width | `e2e/lab-02/responsive.spec.ts` | Planned |
+| RESP-01 | Responsive | AC-25 | Screenshots of Create Ticket, My Tickets, Ticket Detail at desktop/tablet/mobile, written to `artifacts/lab-02/screenshots/{create-ticket,my-tickets,ticket-detail}/` per labsheet §12 | No clipping, overlap, or unintended horizontal scroll at any width | `e2e/lab-02/responsive.spec.ts` | Planned |
 | E2E-01 | E2E | AC-01, AC-07 | Select a Requester, create a Ticket, find it in My Tickets | Ticket appears with the confirmed Ticket Number | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-02 | E2E | AC-03, AC-15 | Requester A creates a Ticket; switch to B; attempt direct access to A's Ticket | Not in B's list; direct access rejected | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-03 | E2E | AC-22, AC-23, AC-24 | Add an attachment, soft-remove it, attempt to download it | Added, then shown removed, then download blocked | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
@@ -90,6 +95,8 @@ are all labsheet requirements with acceptance criteria that need a home to be te
 | AC-25 | RESP-01 |
 | AC-26 | UI-02 |
 | AC-27 | UI-08 |
+| AC-28 | API-19 |
+| AC-29 | API-20, UNIT-02 |
 
 Every AC in `specification.md` §9 maps to at least one test above.
 

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -114,13 +114,19 @@ that same order.
 ## 11. My Tickets — list, search, filter, sort, pagination
 
 **Desktop table columns:** Ticket Number, Summary (truncated with ellipsis past one line),
-Category, Requested Priority (badge), Current Status (badge), Ticket Date, Last Updated, an
-action to open the
-Ticket. **Mobile card:** Ticket Number and Current Status badge on the first line, Summary below
-it, Category/Requested Priority/Ticket Date as a secondary line; the whole card opens the Ticket.
+Category, Requested Priority (badge), Current Status (badge), Ticket Date, Last Updated, and an
+action to open the Ticket. **Mobile card:** Ticket Number and Current Status badge on the first
+line, Summary below it, Category/Requested Priority/Ticket Date as a secondary line, and Last
+Updated on its own line beneath it in small muted text; the whole card opens the Ticket. Last
+Updated is given its own line rather than becoming a fourth item on the secondary line, because
+four items wrap at narrow widths and AC-25 fails on clipped or overlapping content.
 
 Above the list: a search box, filter controls for Category / Related System / Current Status /
-Requested Priority, and a sort control. A **Clear filters** tertiary button appears only once a
+Requested Priority, and a sort control. The sort control offers Ticket Date, Last Updated, Ticket
+Number, Requested Priority and Current Status — the five values `api-spec.md` §4 permits for
+`sort` — each selectable ascending or descending, defaulting to Ticket Date descending (BR-10).
+Every permitted API sort value is reachable from the UI: a sort the user cannot select would have
+no user path. A **Clear filters** tertiary button appears only once a
 search term or filter is active. Pagination controls sit below the list, centered: Previous /
 page numbers / Next. Page size is not exposed as a user control in Lab 2 — the frontend always
 requests the default page size from `api-spec.md`; the query contract's other permitted sizes

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -114,7 +114,8 @@ that same order.
 ## 11. My Tickets — list, search, filter, sort, pagination
 
 **Desktop table columns:** Ticket Number, Summary (truncated with ellipsis past one line),
-Category, Requested Priority (badge), Current Status (badge), Ticket Date, an action to open the
+Category, Requested Priority (badge), Current Status (badge), Ticket Date, Last Updated, an
+action to open the
 Ticket. **Mobile card:** Ticket Number and Current Status badge on the first line, Summary below
 it, Category/Requested Priority/Ticket Date as a secondary line; the whole card opens the Ticket.
 


### PR DESCRIPTION
Prepares #16.

Adds the attachment rules required by labsheet §4.5 that were missing from the merged contract, along with the Last Updated decision for #14.

Documentation only no code changes.

**specification.md**

* Added BR-26 for keeping the uploaded file and database row in sync. If the database write fails, the file is deleted.
* Added BR-27 for the attachment validation order. The first failure wins, with one error per upload. Ownership is checked before the file itself so we don’t reveal another Requester’s Ticket.
* Added BR-28 so uploading or soft-removing an attachment updates the Ticket's `updatedAt`, while Ticket Date stays unchanged.
* Added AC-28 and AC-29 for BR-26 and BR-27.

**api-spec.md**

* Added the BR-27 validation checks in the required order and documented the first-failure-wins rule.
* Added the BR-26 file cleanup behavior and BR-28 timestamp update.
* Added `updatedAt` as an allowed sort value for `GET /api/tickets`.

**ui-spec.md**

* Added Last Updated to the My Tickets desktop table.
* Left the mobile card unchanged because adding another item could cause the wrapping that AC-25 is meant to prevent.

**tests.md**

* Added UNIT-02, UNIT-03, API-19, API-20, and API-21 for the new rules.
* Narrowed UNIT-01 to just the formatting helper since sequence uniqueness is handled by the database and already covered by API-01.
* Added a `sort=updatedAt` case to API-05.
* Added the screenshot output path to RESP-01 as required by labsheet §12.
* Added traceability rows for AC-28 and AC-29.
